### PR TITLE
Update Flask version.

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
-Flask==1.1.2
+Flask==2.1.0
 gunicorn==20.0.4


### PR DESCRIPTION
Currently the application will fail to build with the error:
ImportError: cannot import name 'escape' from 'jinja2'

This change simply updates the version of flask so it does not attempt
to import excape from jinja2.

Signed-off-by: Casey Flynn <caseyflynn@google.com>